### PR TITLE
fix: show-hours-minutes

### DIFF
--- a/src/components/modes/teacher/Responses.js
+++ b/src/components/modes/teacher/Responses.js
@@ -131,7 +131,9 @@ class Responses extends Component {
                         "By clicking 'Delete', you will be deleting student's time. This action cannot be undone.",
                       )}
                       handleClose={this.handleToggleConfirmDialog(false)}
-                      handleConfirm={() => this.handleConfirmDelete(row.appInstanceId)}
+                      handleConfirm={() =>
+                        this.handleConfirmDelete(row.appInstanceId)
+                      }
                       confirmText={t('Delete')}
                       cancelText={t('Cancel')}
                     />

--- a/src/components/modes/teacher/Settings.js
+++ b/src/components/modes/teacher/Settings.js
@@ -163,8 +163,17 @@ class Settings extends Component {
         initialTimeValue: 0,
       });
     } else {
+      const initialTimeValue = Number(value);
+      let hours = Math.floor(initialTimeValue / 60);
+      let minutes = initialTimeValue % 60;
+      hours = hours < 10 ? `0${hours}` : hours;
+      minutes = minutes < 10 ? `0${minutes}` : minutes;
+
+      const showTimeConversion = `${hours} hh : ${minutes} mm `;
+
       this.setState({
-        initialTimeValue: Number(value),
+        initialTimeValue,
+        showTimeConversion,
         showError: false,
       });
     }
@@ -177,6 +186,7 @@ class Settings extends Component {
       initialTimeValue,
       direction,
       showError,
+      showTimeConversion,
       startImmediately,
       timerVisible,
     } = this.state;
@@ -244,7 +254,7 @@ class Settings extends Component {
           label={t('Set counter start time')}
           className={clsx(classes.margin, classes.textField)}
           error={showError}
-          helperText={t('Only positive numbers allowed')}
+          helperText={showTimeConversion}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">Minutes</InputAdornment>


### PR DESCRIPTION
Displays the HH : MM equivalent of a set time
![Timer - Google Chrome 2020-08-01 13 28 34](https://user-images.githubusercontent.com/18397749/89100871-1e7d4680-d3fb-11ea-857d-e05728eccf41.png)
